### PR TITLE
Change lambda for a poisson in simulater.R from integer to real

### DIFF
--- a/R/simulater.R
+++ b/R/simulater.R
@@ -239,7 +239,7 @@ simulater <- function(
   if (pois != "") {
     s <- pois %>% sim_splitter()
     for (i in 1:length(s))
-      s[[i]] %>% {dataset[[.[1]]] <<- rpois(nr, .as_int(.[2], dataset))}
+      s[[i]] %>% {dataset[[.[1]]] <<- rpois(nr, .as_num(.[2], dataset))}
   }
 
   ## parsing sequence


### PR DESCRIPTION
Line #242 of simulater.R uses radiant's as_int for lambda [the mapping to rpois].  With real values between 0 and 1, the variable is always a constant zero.  I changed as_int to as_num and made no other changes to solve the problem that I was experiencing.  I haven't ever really played much with pull requests so the method is perhaps indirect.  I forked the repo, created a new branch with the fix and pulled it back to understand how it works.  This should be easy.

I suppose the one risk that I have not played with is that lambda is constrained to the positive reals.